### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,7 @@
 name: "test"
 on: [pull_request]
+permissions:
+  contents: read
 
 jobs:
   rust-tests:


### PR DESCRIPTION
Potential fix for [https://github.com/scorpion7slayer/NxtGit/security/code-scanning/3](https://github.com/scorpion7slayer/NxtGit/security/code-scanning/3)

To fix the problem, explicitly set restricted `GITHUB_TOKEN` permissions in the workflow. Because this workflow only checks out code, caches builds, and runs tests, it does not need write access to repository contents or other scopes. The minimal safe configuration is to add `permissions: contents: read` at the workflow or job level.

The best fix without changing existing functionality is to add a top-level `permissions` block right under the workflow `name:` (or under `on:`) so it applies to all jobs. Concretely, in `.github/workflows/test.yml`, insert:

```yaml
permissions:
  contents: read
```

between the existing `on: [pull_request]` and `jobs:` lines. No imports or additional methods are needed; this is purely a YAML configuration change within the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
