### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete multi-character sanitization

### DIFF
--- a/src/components/AppChangelog.tsx
+++ b/src/components/AppChangelog.tsx
@@ -197,7 +197,7 @@ const AppChangelog: React.FC = () => {
                       </p>
                       {entry.description && (
                         <p className="text-xs mt-1 line-clamp-2" style={{ color: 'var(--text-secondary)' }}>
-                          {entry.description.replace(/<[^>]*>/g, '').substring(0, 200)}
+                          {DOMPurify.sanitize(entry.description, { ALLOWED_TAGS: [], ALLOWED_ATTR: [] }).substring(0, 200)}
                         </p>
                       )}
                       <div className="flex items-center gap-2 mt-1.5 text-xs" style={{ color: 'var(--text-tertiary)' }}>


### PR DESCRIPTION
Potential fix for [https://github.com/scorpion7slayer/NxtGit/security/code-scanning/1](https://github.com/scorpion7slayer/NxtGit/security/code-scanning/1)

General approach: avoid custom regex-based HTML stripping and instead use a well-tested sanitizer (DOMPurify) to convert the description to plain text, ensuring no residual tag fragments (like `<script`) remain. DOMPurify can be configured to return a string where all markup is removed but text content is preserved.

Best concrete fix here: replace `entry.description.replace(/<[^>]*>/g, '')` with a DOMPurify call that produces plain text, then truncate that. Since DOMPurify is already imported at the top of `AppChangelog.tsx`, we don’t need new imports. A suitable option is `DOMPurify.sanitize(entry.description, { ALLOWED_TAGS: [], ALLOWED_ATTR: [] })`, which strips all HTML tags and attributes, leaving only text. We then apply `.substring(0, 200)` to this sanitized text, just as before.

Change location: in `src/components/AppChangelog.tsx`, around line 198–201 where `entry.description` is rendered. Only that expression needs to be replaced; no extra helpers or methods are strictly required. Functionality remains the same (show up to 200 characters of description text), but we now rely on DOMPurify instead of a brittle regex.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
