### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,9 @@
 name: "lint"
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/scorpion7slayer/NxtGit/security/code-scanning/2](https://github.com/scorpion7slayer/NxtGit/security/code-scanning/2)

To fix the problem, explicitly declare minimal `GITHUB_TOKEN` permissions for this workflow or for the specific `lint` job. Since this workflow only needs to read the repository contents to run Node-based lint/build steps, `contents: read` is sufficient and follows the principle of least privilege.

The best way to fix this without changing functionality is to add a `permissions` block at the workflow root (top-level), so it applies to all jobs (currently just `lint`). Concretely, in `.github/workflows/lint.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` section and the `jobs:` section. No other changes, imports, or additional permissions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
