### PR TITLE
Fix CodeQL 'DOM reinterpreted as HTML' in HTML preview by sanitizing before parse

### DIFF
--- a/src/components/RepoDetail.tsx
+++ b/src/components/RepoDetail.tsx
@@ -1171,7 +1171,6 @@ const CodeTab: React.FC<{ owner: string; name: string; branch: string }> = ({
         }
         let cancelled = false;
         const dirPath = currentPath.split("/").slice(0, -1).join("/");
-        const sourceDoc = new DOMParser().parseFromString(fileContent, "text/html");
 
         (async () => {
             const sanitizedHtml = DOMPurify.sanitize(fileContent, {
@@ -1199,6 +1198,53 @@ const CodeTab: React.FC<{ owner: string; name: string; branch: string }> = ({
             });
             const parser = new DOMParser();
             const doc = parser.parseFromString(sanitizedHtml, "text/html");
+            let interactiveSourceDoc: Document | null = null;
+
+            if (interactiveHtmlPreview) {
+                const sanitizedInteractiveHtml = DOMPurify.sanitize(fileContent, {
+                    WHOLE_DOCUMENT: true,
+                    ADD_TAGS: [
+                        "base",
+                        "body",
+                        "head",
+                        "html",
+                        "link",
+                        "meta",
+                        "script",
+                        "style",
+                        "title",
+                    ],
+                    ADD_ATTR: [
+                        "alt",
+                        "async",
+                        "charset",
+                        "class",
+                        "content",
+                        "crossorigin",
+                        "defer",
+                        "href",
+                        "http-equiv",
+                        "id",
+                        "integrity",
+                        "media",
+                        "name",
+                        "nomodule",
+                        "poster",
+                        "referrerpolicy",
+                        "rel",
+                        "sizes",
+                        "src",
+                        "srcset",
+                        "style",
+                        "type",
+                    ],
+                });
+
+                interactiveSourceDoc = parser.parseFromString(
+                    sanitizedInteractiveHtml,
+                    "text/html",
+                );
+            }
 
             for (const element of Array.from(doc.querySelectorAll("*"))) {
                 for (const attribute of Array.from(element.attributes)) {
@@ -1307,9 +1353,9 @@ const CodeTab: React.FC<{ owner: string; name: string; branch: string }> = ({
                 }
             }
 
-            if (interactiveHtmlPreview) {
+            if (interactiveHtmlPreview && interactiveSourceDoc) {
                 cloneInteractiveScripts(
-                    sourceDoc,
+                    interactiveSourceDoc,
                     doc,
                     owner,
                     name,


### PR DESCRIPTION
### Motivation
- CodeQL flagged a risky pattern where raw file HTML was parsed directly with `DOMParser.parseFromString`, which can reinterpret untrusted input as executable HTML and reintroduce XSS vectors. 
- The app needs to keep interactive previews (opt-in) while preserving strong sanitization for default previews to avoid executing repository scripts in the app context.

### Description
- Stop parsing raw `fileContent` directly; run `DOMPurify.sanitize` first and parse the sanitized HTML for the normal (static) preview using `DOMParser`. 
- Add an explicitly sanitized interactive source document that allows `script` tags only when `interactiveHtmlPreview` is enabled, and use that sanitized doc for `cloneInteractiveScripts` so scripts are only cloned from an already-sanitized source. 
- Continue to forbid inline event handler attributes and keep normal preview mode with `script` removed and the iframe sandboxed, with interactive mode opt-in and separately hardened. 

### Testing
- Ran `npm run build`, which completed successfully and the frontend build passed. 
- Attempted `cargo check --manifest-path src-tauri/Cargo.toml`, which failed in this environment due to a missing system dependency (`glib-2.0` / `pkg-config`), so full Rust validation requires CI or a host with that system package available. 
- Manual inspections verified the sanitization path and that interactive cloning is gated by the sanitized interactive document.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af765117288321b6d2b54e63bcff0b)