### PR TITLE
Update analytics & demo video

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -27,8 +27,8 @@
             type="image/png"
         />
         <script
-            src="https://analyticstheo.serverscorpion1601.site/api/script.js"
-            data-site-id="3a3692b313b0"
+            src="https://rybbit.nxtaigen.com/api/script.js"
+            data-site-id="cc03f3fa4cad"
             defer
         ></script>
         <style>
@@ -664,18 +664,12 @@
             <div class="container">
                 <div class="video-wrapper">
                     <iframe
-                        src="https://www.youtube.com/embed/W2mVp_yVHcA?rel=0&modestbranding=1"
-                        title="NxtGit Demo"
-                        allow="
-                            accelerometer;
-                            autoplay;
-                            clipboard-write;
-                            encrypted-media;
-                            gyroscope;
-                            picture-in-picture;
-                            web-share;
-                        "
+                        src="https://cap.so/embed/9knyk9srj09a7st"
+                        frameborder="0"
+                        webkitallowfullscreen
+                        mozallowfullscreen
                         allowfullscreen
+                        title="NxtGit Demo"
                     >
                     </iframe>
                 </div>


### PR DESCRIPTION
Replace old analytics with Rybbit (rybbit.nxtaigen.com, site cc03f3fa4cad) and swap YouTube embed for cap.so demo.