### PR TITLE
Mark NxtGit as archived

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -598,7 +598,6 @@
                 <div class="nav-links">
                     <a href="#features">Features</a>
                     <a href="#providers">AI Providers</a>
-                    <a href="#download">Download</a>
                     <a
                         href="https://github.com/scorpion7slayer/NxtGit"
                         class="btn btn-secondary btn-sm"
@@ -613,17 +612,17 @@
             <div class="container">
                 <div class="hero-badge">
                     <span class="dot"></span>
-                    v1.1.1 — Open Source
+                    Archived on GitHub
                 </div>
-                <h1>Your GitHub workflow,<br /><span>powered by AI</span></h1>
+                <h1>NxtGit is<br /><span>no longer maintained</span></h1>
                 <p>
-                    Browse repos, review code, chat with AI, edit files, and
-                    push — all from one native desktop app. Built with Tauri,
-                    React, and Rust.
+                    This application has been archived on GitHub. It will no
+                    longer receive updates, bug fixes, security fixes, or
+                    support.
                 </p>
                 <div class="hero-actions">
                     <a
-                        href="https://github.com/scorpion7slayer/NxtGit/releases"
+                        href="https://github.com/scorpion7slayer/NxtGit"
                         class="btn btn-primary"
                     >
                         <svg
@@ -642,18 +641,7 @@
                             <polyline points="7 10 12 15 17 10" />
                             <line x1="12" y1="15" x2="12" y2="3" />
                         </svg>
-                        Download
-                    </a>
-                    <a href="#demo" class="btn btn-secondary">
-                        <svg
-                            width="16"
-                            height="16"
-                            fill="currentColor"
-                            viewBox="0 0 24 24"
-                        >
-                            <polygon points="5 3 19 12 5 21 5 3" />
-                        </svg>
-                        Watch Demo
+                        View archived repository
                     </a>
                 </div>
             </div>
@@ -926,13 +914,13 @@
         </section>
 
         <!-- Platforms -->
-        <section class="platforms" id="download">
+        <section class="platforms">
             <div class="container">
-                <p class="section-label">Download</p>
-                <h2 class="section-title">Native on every platform</h2>
+                <p class="section-label">Availability</p>
+                <h2 class="section-title">Archived project</h2>
                 <p class="section-desc">
-                    Built with Tauri v2 — Rust backend, tiny binary, no Electron
-                    bloat.
+                    Existing releases may remain available, but they are no
+                    longer updated or supported.
                 </p>
                 <div class="platforms-row">
                     <div class="platform-card">
@@ -958,13 +946,14 @@
         <section class="cta">
             <div class="container">
                 <div class="cta-box">
-                    <h2>Ready to try NxtGit?</h2>
+                    <h2>NxtGit has been archived</h2>
                     <p>
-                        Free and open source. Download now or build from source.
+                        The source code is kept on GitHub for reference only.
+                        This project is no longer maintained.
                     </p>
                     <div class="cta-actions">
                         <a
-                            href="https://github.com/scorpion7slayer/NxtGit/releases"
+                            href="https://github.com/scorpion7slayer/NxtGit"
                             class="btn btn-primary"
                         >
                             <svg
@@ -983,13 +972,7 @@
                                 <polyline points="7 10 12 15 17 10" />
                                 <line x1="12" y1="15" x2="12" y2="3" />
                             </svg>
-                            Download Latest Release
-                        </a>
-                        <a
-                            href="https://github.com/scorpion7slayer/NxtGit"
-                            class="btn btn-secondary"
-                        >
-                            View on GitHub
+                            View archived repository
                         </a>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary

- replace download-focused messaging with a clear archived-project notice
- direct visitors to the archived GitHub repository instead of releases
- clarify that the project no longer receives updates, fixes, or support

## Validation

- `git diff --check`